### PR TITLE
Fix non-bare repo to use pull instead of fetch

### DIFF
--- a/sync.php
+++ b/sync.php
@@ -279,7 +279,7 @@
 				// Pull
 				$branch = $branchName != '*' ? 'origin '.$branchName : '--all';
 				$pull = $branchConfig->bare ? 'fetch' : 'pull';
-				$command = 'git fetch '.$branch;
+				$command = 'git '.$pull.' '.$branch;
 				$returnCode = _executeCommand('Pulling', $command, $config->retryOnErrorCount, '_cleanUntrackedStuff', $branchConfig );
 				if($returnCode) {
 					// Error, stop execution


### PR DESCRIPTION
Running sync.php on non-bare repository, instead of running git pull, always runs git fetch, which does not merge changes from upstream to local.
