### PR TITLE
Fix php tag to be valid for current php.ini files (<?php)

### DIFF
--- a/sync.php
+++ b/sync.php
@@ -78,7 +78,7 @@
 </head>
 <body style="background-color: #404040; color: #FFFFFF;">
 <div style="box-sizing: border-box; padding: 15px; width: 100%; height: 100%; background-color: #404040; color: #FFFFFF;">
-<?
+<?php
 
 	flush();
 


### PR DESCRIPTION
Default `php.ini` files from Debian / Ubuntu systems requires an valid php tag `<?php` instead of only `<?`.
